### PR TITLE
Improve the tooltip text and add the vertical chart

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^\.github$
 ^init\.R$
 ^heroku\.yml$
+^app\.json$

--- a/R/app.R
+++ b/R/app.R
@@ -57,8 +57,8 @@ run_app <- function(...){
     # Convert the recommend column to a factor
     recommend_levels <- c("Definitely would NOT recommend",
                           "Probably would NOT recommend",
-                          "Definitely would recommend",
-                          "Probably would recommend")
+                          "Probably would recommend",
+                          "Definitely would recommend")
     responses <- responses %>%
       dplyr::mutate(recommend = factor(recommend, levels = recommend_levels))
 

--- a/R/app.R
+++ b/R/app.R
@@ -36,8 +36,9 @@ run_app <- function(...){
     # Body of the page
     shiny::withTags(
       # Render Card
-      div(class = "d-flex flex-column flex-lg-row container",
+      div(class = "d-flex flex-column flex-lg-row container justify-content-center",
           div(class = "container card border-light bg-info m-2",
+              style = "max-width: 50rem",
               div(class = "card-body",
                   net_promoter_score_UI("nps")
               )

--- a/R/app.R
+++ b/R/app.R
@@ -53,6 +53,15 @@ run_app <- function(...){
     responses <- get_survey_data()
 
     # Update the responses dataset
+    # Net promoter scores
+    # Convert the recommend column to a factor
+    recommend_levels <- c("Definitely would NOT recommend",
+                          "Probably would NOT recommend",
+                          "Definitely would recommend",
+                          "Probably would recommend")
+    responses <- responses %>%
+      dplyr::mutate(recommend = factor(recommend, levels = recommend_levels))
+
     # Add two groups for the net promoter scores
     responses <- responses %>%
       dplyr::mutate(recommend_2gp = dplyr::case_when(

--- a/R/net_promoter_score.R
+++ b/R/net_promoter_score.R
@@ -134,7 +134,7 @@ net_promoter_score_server <- function(id, data) {
           round(prop * 100, 1), "% ",
           "of participants answered that they would ",
           tolower(recommend_abbr),
-          " this community to someone else as a good place to live"
+          " recommend this community to someone else as a good place to live"
         )) %>%
         # Add line breaks to hover text
         dplyr::mutate(hovertext = stringr::str_wrap(hovertext, width = 25))

--- a/R/net_promoter_score.R
+++ b/R/net_promoter_score.R
@@ -90,7 +90,8 @@ net_promoter_score_server <- function(id, data) {
           plotly::config(displayModeBar = FALSE) %>%
           plotly::add_annotations(text = sprintf("%.1f%%", would_recommend_prop * 100),
                                   showarrow = FALSE,
-                                  font = list(size = 50)) %>%
+                                  font = list(size = 50,
+                                              color = "#00A454")) %>%
           plotly::add_annotations(text = "Would Recommend",
                                   x = 1.05,
                                   y = -0.03,

--- a/R/net_promoter_score.R
+++ b/R/net_promoter_score.R
@@ -100,7 +100,9 @@ net_promoter_score_server <- function(id, data) {
                                   x = 0.10,
                                   y = 0.95,
                                   showarrow = FALSE,
-                                  font = list(size = 15))
+                                  font = list(size = 15)) %>%
+          # Disable drag
+          plotly::layout(dragmode = FALSE)
       }
     )
 
@@ -183,9 +185,11 @@ net_promoter_score_server <- function(id, data) {
         plotly::layout(legend = list(itemclick = FALSE, itemdoubleclick = FALSE)) %>%
         # Disable zoom
         plotly::layout(xaxis = list(fixedrange = TRUE),
-                       yaxis = list(fixedrange = TRUE))
-
-
+                       yaxis = list(fixedrange = TRUE)) %>%
+        # Reduce margin
+        plotly::layout(margin = list(l = 5, r = 5)) %>%
+        # Disable drag
+        plotly::layout(dragmode = FALSE)
 
     })
 

--- a/R/net_promoter_score.R
+++ b/R/net_promoter_score.R
@@ -9,16 +9,25 @@
 #' net_promoter_score_UI("nps")
 net_promoter_score_UI <- function(id) {
   shiny::withTags(
-    div(class = "d-flex flex-column align-items-center",
-        h1(class = "text-center",
-           "Net Promoter Score"),
-        div(class = "text-secondary my-3",
-            style = "max-width: 30rem",
-            "How likely are you to recommend this community to someone else as a good place to live?"),
-        div(
-          plotly::plotlyOutput(shiny::NS(id, "plot"), width = "400px"),
-          align = "center"
-        )
+    shiny::tagList(
+      div(class = "d-flex flex-column align-items-center",
+          h1(class = "text-center fw-bold",
+             "Net Promoter Score"),
+          div(class = "my-3 fs-5",
+              style = "max-width: 30rem",
+              "How likely are you to recommend this community to someone else as a good place to live?"),
+          div(
+            plotly::plotlyOutput(shiny::NS(id, "plot"), width = "400px"),
+            align = "center"
+          )
+      ),
+      div(id = "vertical-bar-container",
+          hr(),
+          h3("Breakdown", class = "text-center"),
+          div(
+            plotly::plotlyOutput(shiny::NS(id, "vertical_plot"), width = "400px"),
+            align = "center"
+          ))
     )
   )
 }
@@ -46,14 +55,35 @@ net_promoter_score_server <- function(id, data) {
           dplyr::mutate(color = dplyr::case_when(recommend_2gp == "Would recommend" ~ "#00A454",
                                                  recommend_2gp == "Would NOT recommend" ~ "#494F56"))
 
+        question_categories <- data %>%
+          dplyr::pull(recommend)
+
+        # Prepare the center annotation
         would_recommend_prop <- nps_summary %>%
           dplyr::filter(recommend_2gp == "Would recommend") %>%
           dplyr::pull(prop)
 
+        # Prepare hovertext
+        nps_summary <- nps_summary %>%
+          dplyr::mutate(hovertext_abbr = dplyr::case_when(recommend_2gp == "Would recommend" ~ "would or probably would",
+                                                          recommend_2gp == "Would NOT recommend" ~ "would NOT or probably would NOT"))
+        nps_summary <- nps_summary %>%
+          dplyr::mutate(hovertext = paste0(
+            round(prop * 100, 1), "% ",
+            "of participants answered that they ",
+            hovertext_abbr,
+            " recommend this community to someone else as a good place to live"
+          )) %>%
+          # Add line breaks
+          dplyr::mutate(hovertext = stringr::str_wrap(hovertext, 25))
+
         nps_summary %>%
           plotly::plot_ly(values = ~prop,
                           marker = list(colors = ~color),
-                          textinfo = "none") %>%
+                          textinfo = "none",
+                          customdata  = ~tolower(recommend_2gp),
+                          hoverinfo = "text",
+                          hovertext = ~hovertext) %>%
           plotly::add_pie(hole = 0.6) %>%
           plotly::layout(showlegend = F,
                          margin = list(l = 20, r = 20)) %>%
@@ -73,6 +103,91 @@ net_promoter_score_server <- function(id, data) {
                                   font = list(size = 15))
       }
     )
+
+    output$vertical_plot <- plotly::renderPlotly({
+      vertical_bar_summary <- data %>%
+        dplyr::count(recommend) %>%
+        dplyr::mutate(prop = n / sum(n))
+
+
+      dplyr::glimpse(vertical_bar_summary)
+
+      # Prepare the annotations
+      vertical_bar_summary <- vertical_bar_summary %>%
+        # Set abbreviation for annotation
+        dplyr::mutate(recommend_abbr = dplyr::case_when(
+          recommend == "Definitely would recommend" ~ "Definitely",
+          recommend == "Probably would recommend" ~ "Probably",
+          recommend == "Definitely would NOT recommend" ~ "Definitely NOT",
+          recommend == "Probably would NOT recommend" ~ "Probably NOT"
+        )) %>%
+        dplyr::mutate(annotation = paste0(
+          round(prop * 100, 1), "% ", recommend_abbr
+        ))
+
+      # Prepare the hovertext texts
+      vertical_bar_summary <- vertical_bar_summary %>%
+        dplyr::mutate(hovertext = paste0(
+          round(prop * 100, 1), "% ",
+          "of participants answered that they would ",
+          tolower(recommend_abbr),
+          " this community to someone else as a good place to live"
+        )) %>%
+        # Add line breaks to hover text
+        dplyr::mutate(hovertext = stringr::str_wrap(hovertext, width = 25))
+
+      # Calculate the positions for the annotations
+      vertical_bar_summary <- vertical_bar_summary %>%
+        dplyr::arrange(recommend) %>%
+        dplyr::mutate(y_pos_annotation = cumsum(prop) - (prop / 2))
+
+      # Set colors for the vertical bar
+      vbar_colors <- c("#494F56", "#A6A6A6",
+                       "#00A454", "#00CF6A")
+      question_categories <- data %>%
+        dplyr::pull(recommend)
+      # Add color column
+      vertical_bar_summary <- vertical_bar_summary %>%
+        dplyr::mutate(color = vbar_colors)
+
+      # Create the vertical plot
+      vertical_bar_summary %>%
+        plotly::plot_ly(y = ~prop,
+                        x = 1,
+                        color = ~I(color),
+                        hoverinfo = "text",
+                        hovertext = ~hovertext) %>%
+        plotly::add_bars() %>%
+        plotly::layout(barmode = "stack") %>%
+        # Add annotations
+        plotly::add_annotations(text = ~annotation,
+                                x = 1.5,
+                                y = ~y_pos_annotation,
+                                showarrow = FALSE,
+                                font = list(size = 16),
+                                xanchor = "left") %>%
+        # Remove axis labels
+        plotly::layout(yaxis = list(title = ""),
+                       xaxis = list(title = "")) %>%
+        # Remove ticks and grids
+        plotly::layout(yaxis = list(showticklabels = FALSE,
+                                    showgrid = FALSE,
+                                    zeroline = FALSE),
+                       xaxis = list(showticklabels = FALSE,
+                                    showgrid = FALSE)) %>%
+        # Hide Legend
+        plotly::hide_legend() %>%
+        # Remove mode bar
+        plotly::config(displayModeBar = FALSE) %>%
+        # Disable the click
+        plotly::layout(legend = list(itemclick = FALSE, itemdoubleclick = FALSE)) %>%
+        # Disable zoom
+        plotly::layout(xaxis = list(fixedrange = TRUE),
+                       yaxis = list(fixedrange = TRUE))
+
+
+
+    })
 
   })
 }

--- a/R/net_promoter_score.R
+++ b/R/net_promoter_score.R
@@ -17,7 +17,7 @@ net_promoter_score_UI <- function(id) {
               style = "max-width: 30rem",
               "How likely are you to recommend this community to someone else as a good place to live?"),
           div(
-            plotly::plotlyOutput(shiny::NS(id, "plot"), width = "400px"),
+            plotly::plotlyOutput(shiny::NS(id, "plot"), width = "20rem"),
             align = "center"
           )
       ),
@@ -25,7 +25,7 @@ net_promoter_score_UI <- function(id) {
           hr(),
           h3("Breakdown", class = "text-center"),
           div(
-            plotly::plotlyOutput(shiny::NS(id, "vertical_plot"), width = "400px"),
+            plotly::plotlyOutput(shiny::NS(id, "vertical_plot"), width = "20rem"),
             align = "center"
           ))
     )

--- a/app.json
+++ b/app.json
@@ -1,3 +1,3 @@
 {
-  "stack": "Container"
+  "stack": "container"
 }

--- a/app.json
+++ b/app.json
@@ -1,4 +1,3 @@
 {
-  "name": "WRK Survey Dashboard",
-  "stack": "Container",
+  "stack": "Container"
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "WRK Survey Dashboard",
+  "stack": "Container",
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,4 @@
 build:
   docker:
     web: Dockerfile
+    worker: worker/Dockerfile

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,4 +1,3 @@
 build:
   docker:
     web: Dockerfile
-    worker: worker/Dockerfile


### PR DESCRIPTION
This PR improves the tooltip text of the donut chart. Fixes #16.

This PR also has scope-creeped 😅 and adds the vertical bar chart to show the breakdown of the responses.